### PR TITLE
Modify Check to return a slice of results

### DIFF
--- a/checker.go
+++ b/checker.go
@@ -60,7 +60,7 @@ func (c *Checker) Check(ctx context.Context) []Result {
 
 	type namedResult struct {
 		name   string
-		result Result
+		result []Result
 	}
 
 	timedout := make(map[string]struct{}, len(c.checks))
@@ -94,7 +94,7 @@ func (c *Checker) Check(ctx context.Context) []Result {
 			}
 			break
 		case r := <-res:
-			results = append(results, r.result)
+			results = append(results, r.result...)
 			delete(timedout, r.name)
 		}
 	}

--- a/checker_test.go
+++ b/checker_test.go
@@ -11,12 +11,14 @@ import (
 func TestChecker(t *testing.T) {
 	gimmieCheck := func(status int, name, message string, sleep time.Duration) *CheckMock {
 		return &CheckMock{
-			CheckFunc: func(ctx context.Context) Result {
+			CheckFunc: func(ctx context.Context) []Result {
 				time.Sleep(sleep)
-				return Result{
-					Status:  status,
-					Name:    name,
-					Message: message,
+				return []Result{
+					{
+						Status:  status,
+						Name:    name,
+						Message: message,
+					},
 				}
 			},
 			NameFunc: func() string {

--- a/checks/aws_ses.go
+++ b/checks/aws_ses.go
@@ -33,7 +33,7 @@ func (c *AWSSESVerificationStatusCheck) Name() string {
 }
 
 // Check executes the check.
-func (c *AWSSESVerificationStatusCheck) Check(ctx context.Context) preflight.Result {
+func (c *AWSSESVerificationStatusCheck) Check(ctx context.Context) []preflight.Result {
 	in := &ses.GetIdentityVerificationAttributesInput{
 		Identities: []*string{&c.address},
 	}
@@ -41,12 +41,13 @@ func (c *AWSSESVerificationStatusCheck) Check(ctx context.Context) preflight.Res
 	result := preflight.Result{
 		Name: c.Name(),
 	}
+	var results []preflight.Result
 
 	out, err := c.svc.GetIdentityVerificationAttributesWithContext(ctx, in)
 	if err != nil {
 		result.Message = err.Error()
 		result.Status = preflight.StatusRed
-		return result
+		return append(results, result)
 	}
 
 	attrs, ok := out.VerificationAttributes[c.address]
@@ -61,7 +62,7 @@ func (c *AWSSESVerificationStatusCheck) Check(ctx context.Context) preflight.Res
 		result.Message = "Address has been verified."
 	}
 
-	return result
+	return append(results, result)
 }
 
 // AWSSESAccountSendingEnabledCheck is a preflight.Check that looks at whether or
@@ -85,7 +86,7 @@ func (c *AWSSESAccountSendingEnabledCheck) Name() string {
 }
 
 // Check executes the check.
-func (c *AWSSESAccountSendingEnabledCheck) Check(ctx context.Context) preflight.Result {
+func (c *AWSSESAccountSendingEnabledCheck) Check(ctx context.Context) []preflight.Result {
 	in := &ses.GetAccountSendingEnabledInput{}
 
 	result := preflight.Result{
@@ -93,12 +94,13 @@ func (c *AWSSESAccountSendingEnabledCheck) Check(ctx context.Context) preflight.
 		Message: "Sending has been enabled.",
 		Status:  preflight.StatusGreen,
 	}
+	var results []preflight.Result
 
 	out, err := c.svc.GetAccountSendingEnabledWithContext(ctx, in)
 	if err != nil {
 		result.Message = err.Error()
 		result.Status = preflight.StatusRed
-		return result
+		return append(results, result)
 	}
 
 	if !*out.Enabled {
@@ -106,5 +108,5 @@ func (c *AWSSESAccountSendingEnabledCheck) Check(ctx context.Context) preflight.
 		result.Status = preflight.StatusRed
 	}
 
-	return result
+	return append(results, result)
 }

--- a/checks/aws_ses_test.go
+++ b/checks/aws_ses_test.go
@@ -69,9 +69,9 @@ func TestAWSSESVerificationStatusCheck(t *testing.T) {
 			check := NewAWSSESVerificationStatusCheck(svc, addr)
 			result := check.Check(context.Background())
 
-			require.Equal(t, tt.expected.Name, result.Name)
-			require.Equal(t, tt.expected.Status, result.Status)
-			require.Equal(t, tt.expected.Message, result.Message)
+			require.Equal(t, tt.expected.Name, result[0].Name)
+			require.Equal(t, tt.expected.Status, result[0].Status)
+			require.Equal(t, tt.expected.Message, result[0].Message)
 		})
 	}
 }
@@ -108,9 +108,9 @@ func TestAWSSESAccountSendingEnabledCheck(t *testing.T) {
 			check := NewAWSSESAccountSendingEnabledCheck(svc)
 			result := check.Check(context.Background())
 
-			require.Equal(t, tt.expected.Name, result.Name)
-			require.Equal(t, tt.expected.Status, result.Status)
-			require.Equal(t, tt.expected.Message, result.Message)
+			require.Equal(t, tt.expected.Name, result[0].Name)
+			require.Equal(t, tt.expected.Status, result[0].Status)
+			require.Equal(t, tt.expected.Message, result[0].Message)
 		})
 	}
 }

--- a/mock_check.go
+++ b/mock_check.go
@@ -23,7 +23,7 @@ var _ Check = &CheckMock{}
 //
 //         // make and configure a mocked Check
 //         mockedCheck := &CheckMock{
-//             CheckFunc: func(ctx context.Context) Result {
+//             CheckFunc: func(ctx context.Context) []Result {
 // 	               panic("mock out the Check method")
 //             },
 //             NameFunc: func() string {
@@ -37,7 +37,7 @@ var _ Check = &CheckMock{}
 //     }
 type CheckMock struct {
 	// CheckFunc mocks the Check method.
-	CheckFunc func(ctx context.Context) Result
+	CheckFunc func(ctx context.Context) []Result
 
 	// NameFunc mocks the Name method.
 	NameFunc func() string
@@ -56,7 +56,7 @@ type CheckMock struct {
 }
 
 // Check calls CheckFunc.
-func (mock *CheckMock) Check(ctx context.Context) Result {
+func (mock *CheckMock) Check(ctx context.Context) []Result {
 	if mock.CheckFunc == nil {
 		panic("CheckMock.CheckFunc: method is nil but Check.Check was just called")
 	}

--- a/preflight.go
+++ b/preflight.go
@@ -18,8 +18,8 @@ const (
 type Check interface {
 	// Name should return a unique name for this check.
 	Name() string
-	// Check should execute the check and return the Result.
-	Check(ctx context.Context) Result
+	// Check should execute the check and return a list of Results.
+	Check(ctx context.Context) []Result
 }
 
 // Result represents the result of a check.


### PR DESCRIPTION
Modify Check to have the ability to return multiple results.  Example would be checking an Autoscaling Group if we reached max size or if we have unhealthy instances.